### PR TITLE
PSP adopts SNES layout

### DIFF
--- a/lemuroid-touchinput/src/main/java/com/swordfish/touchinput/pads/GamePadFactory.kt
+++ b/lemuroid-touchinput/src/main/java/com/swordfish/touchinput/pads/GamePadFactory.kt
@@ -9,7 +9,8 @@ class GamePadFactory {
         GBA,
         GENESIS,
         N64,
-        PSX
+        PSX,
+        PSP
     }
 
     companion object {
@@ -20,6 +21,7 @@ class GamePadFactory {
                 Layout.GENESIS -> GenesisPad(context)
                 Layout.GBA -> GameBoyAdvancePad(context)
                 Layout.PSX -> PSXPad(context)
+                Layout.PSP -> SNESPad(context)
                 Layout.N64 -> N64Pad(context)
             }
         }


### PR DESCRIPTION
Most PSP games don't require analog stick. Can be addressed in the future with Dreamcast due to sharing layout.